### PR TITLE
more descriptive background blocks

### DIFF
--- a/MBXMapKit/MBXRasterTileOverlay.m
+++ b/MBXMapKit/MBXRasterTileOverlay.m
@@ -588,7 +588,7 @@
         {
             // Since the URL was successfully retrieved, invoke the block to process its data
             //
-            workerBlock(data, &error);
+            if (workerBlock) workerBlock(data, &error);
         }
         completionHandler(data,error);
     }
@@ -610,7 +610,7 @@
                 {
                     // Since the URL was successfully retrieved, invoke the block to process its data
                     //
-                    workerBlock(data,&error);
+                    if (workerBlock) workerBlock(data, &error);
                 }
             }
 


### PR DESCRIPTION
This is pretty minor, but inside the implementation of `MBXRasterTileOverlay`, `dataBlock` doesn't indicate enough to me what's going on. Something like `workerBlock` emphasizes that it's some background work that's happening. 

Additionally, in the first case, just pass `nil` instead of an empty block. This is more standard in Apple's APIs. 
