### PR TITLE
Prevent init being called using an LLVM extension.

### DIFF
--- a/MBXMapKit/MBXOfflineMapDatabase.h
+++ b/MBXMapKit/MBXOfflineMapDatabase.h
@@ -27,4 +27,7 @@
 
 - (void)invalidate;
 
+// prevent init from being used
+- (instancetype)init __attribute__((unavailable("To instantiate MBXOfflineMapDatabase objects, please use the cababilities provided by MBXOfflineMapDatabase.")));
+
 @end

--- a/MBXMapKit/MBXOfflineMapDatabase.m
+++ b/MBXMapKit/MBXOfflineMapDatabase.m
@@ -46,14 +46,6 @@
 
 @implementation MBXOfflineMapDatabase
 
-- (id)init
-{
-    NSLog(@"\n\n-init should not be called directly. To instantiate MBXOfflineMapDatabase objects, please use the cababilities provided by MBXOfflineMapDatabase.\n\n");
-    BOOL properInstantiationOfMBXOfflineMapDatabase = NO;
-    assert(properInstantiationOfMBXOfflineMapDatabase);
-    return nil;
-}
-
 
 - (id)initWithContentsOfFile:(NSString *)path
 {


### PR DESCRIPTION
Instead of failing an assertion in the init method, a call to init can be prevented using `__attribute__((unavailable("message to the developer")))`.

This prevents the usage before even running the project (A compiler error is raised as soon as you try to use init) which I would consider an advantage.
