### PR TITLE
Issue3 mbtiles hybrid solution

### DIFF
--- a/Sample Project/MBXMapKit iOS/MBXViewController.m
+++ b/Sample Project/MBXMapKit iOS/MBXViewController.m
@@ -172,6 +172,11 @@
     [_rasterOverlay invalidateAndCancel];
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     _currentlyViewingAnOfflineMap = NO;
+    
+    if (_mbtilesOverlay)
+    {
+        [_mapView removeOverlay:_mbtilesOverlay];
+    }
 }
 
 


### PR DESCRIPTION
I removed the background queue and loading should be done on the thread calling `loadMBTilesDataForPath:...`. I also fixed the example app correctly removing the mbtiles layer when switching to a different overlay.

No matter how often I read http://dev.yorhel.nl/doc/sqlaccess, I am still not sure, that my solution is actually better than @wsnook's original implementation, it only takes less memory for sure. It probably boils down to how often MapKit creates new threads for loading tiles.
