### PR TITLE
Support multiple offline databases in the same overlay

### DIFF
--- a/MBXMapKit/MBXRasterTileOverlay.h
+++ b/MBXMapKit/MBXRasterTileOverlay.h
@@ -102,6 +102,11 @@ extern NSInteger const MBXMapKitErrorCodeDictionaryMissingKeys;
 *   @return An initialized raster tile overlay, or `nil` if an overlay could not be initialized. */
 - (instancetype)initWithOfflineMapDatabase:(MBXOfflineMapDatabase *)offlineMapDatabase;
 
+/** Initialize from an `MBXOfflineMapDatabase` array, using its stored values for metadata and markers, if it has any (Values for mapId, metadata, markers and image must be the same among all databases)
+ *   @param offlineMapDatabases An Array of offline map database objects obtained from `MBXOfflineMapDownloader`
+ *   @return An initialized raster tile overlay, or `nil` if an overlay could not be initialized. */
+- (instancetype)initWithOfflineMapDatabases:(NSArray *)offlineMapDatabases;
+
 /** @name Accessing the Delegate */
 
 /** Delegate to notify of asynchronous resource load completion events. */


### PR DESCRIPTION
This enable a single overlay to display all saved offline databases. 

In my use case, I have a feature where users can save map region for offline use. When switching to offline mode, I want the map to show all saved region at the same time without having to add a new overlay for every region saved offline.
